### PR TITLE
Fix div zero enrichment error

### DIFF
--- a/AMON/predict_metabolites.py
+++ b/AMON/predict_metabolites.py
@@ -244,7 +244,8 @@ def calculate_enrichment(cos, co_pathway_dict, min_pathway_size=10):
     # otherwise there's a zero division error during p adj
     if len(enrichment_table.index)==0:
         raise ValueError("No pathways were identified from the KOs provided."
-                         "Please verify that your KOs are valid (e.g., formatted as K02041).")
+                         "Please verify that your KOs are valid (e.g., formatted as K02041)."
+                         "If KOs are correctly formatted, consider lowering the min pathway size param.")
     enrichment_table['adjusted probability'] = p_adjust(enrichment_table.probability)
     if np.any((enrichment_table['adjusted probability'] < .05) & (enrichment_table['overlap'] == 0)):
         return None

--- a/AMON/predict_metabolites.py
+++ b/AMON/predict_metabolites.py
@@ -243,7 +243,8 @@ def calculate_enrichment(cos, co_pathway_dict, min_pathway_size=10):
     # if 0 rows in enrichment table, return None
     # otherwise there's a zero division error during p adj
     if len(enrichment_table.index)==0:
-        return None
+        raise ValueError("No pathways were identified from the KOs provided."
+                         "Please verify that your KOs are valid (e.g., formatted as K02041).")
     enrichment_table['adjusted probability'] = p_adjust(enrichment_table.probability)
     if np.any((enrichment_table['adjusted probability'] < .05) & (enrichment_table['overlap'] == 0)):
         return None

--- a/AMON/predict_metabolites.py
+++ b/AMON/predict_metabolites.py
@@ -240,6 +240,10 @@ def calculate_enrichment(cos, co_pathway_dict, min_pathway_size=10):
             pathway_data.append([len(pathway_present), len(overlap), prob])
     enrichment_table = pd.DataFrame(pathway_data, index=pathway_names,
                                     columns=["pathway size", "overlap", "probability"])
+    # if 0 rows in enrichment table, return None
+    # otherwise there's a zero division error during p adj
+    if len(enrichment_table.index)==0:
+        return None
     enrichment_table['adjusted probability'] = p_adjust(enrichment_table.probability)
     if np.any((enrichment_table['adjusted probability'] < .05) & (enrichment_table['overlap'] == 0)):
         return None


### PR DESCRIPTION
If there are only a few KOs being assessed, if the KOs all belong to small pathways, or the KOs are incorrectly formatted, there will be no rows in the table. When performing p value adjustment, this will cause a division by 0 error. 

I've added a check to see if there are 0 rows. If there are 0 rows, AMON now raises a more informative error. 

This seems to make using more clear/robust for issues such as #12 .