### PR TITLE
update error message to not suggest lowering the pathway size

### DIFF
--- a/AMON/predict_metabolites.py
+++ b/AMON/predict_metabolites.py
@@ -244,8 +244,7 @@ def calculate_enrichment(cos, co_pathway_dict, min_pathway_size=10):
     # otherwise there's a zero division error during p adj
     if len(enrichment_table.index)==0:
         raise ValueError("No pathways were identified from the KOs provided."
-                         "Please verify that your KOs are valid (e.g., formatted as K02041)."
-                         "If KOs are correctly formatted, consider lowering the min pathway size param.")
+                         "Please verify that your KOs are valid (e.g., formatted as K02041).")
     enrichment_table['adjusted probability'] = p_adjust(enrichment_table.probability)
     if np.any((enrichment_table['adjusted probability'] < .05) & (enrichment_table['overlap'] == 0)):
         return None


### PR DESCRIPTION
We discussed during code review that we probably shouldn't have the error message suggesting to lower the min pathway size because (a) we don't have functionality to do so, and (b) we might not want to include pathways smaller than that.

This addresses issue #15 .