### PR TITLE
update get_rns_from_kos based on new KEGG_Parser return from KEGG API updates

### DIFF
--- a/tests/test_predict_metabolites.py
+++ b/tests/test_predict_metabolites.py
@@ -129,7 +129,7 @@ def test_read_in_ids_bad_ending():
 
 @pytest.fixture()
 def ko_dict():
-    ko1 = {'ENTRY': 'K00001', 'DBLINKS': {'RN': ['R00000', 'R00001']}}
+    ko1 = {'ENTRY': 'K00001', 'REACTION': ['R00000', 'R00001']}
     ko2 = {'ENTRY': 'K00002', 'DBLINKS': {'COG': ['COG0000']}}
     return {'K00001': ko1, 'K00002': ko2}
 


### PR DESCRIPTION
Addresses https://github.com/lozuponelab/AMON/issues/19 , which arose from changes to KEGG's representation of the `REACTION` field. Also see KEGG_Parser https://github.com/lozuponelab/KEGG_parser/pull/19